### PR TITLE
Inactive dayselector feedback

### DIFF
--- a/sources/components/dateEntry.js
+++ b/sources/components/dateEntry.js
@@ -61,33 +61,28 @@ class DateEntry extends HTMLElement {
   /**
    * Checks if active is set to true or false
    */
-  get checkActive() {
-    if (this.shadowRoot.querySelector(".active").innerText == "true") {
-      return true;
-    } else {
-      return false;
-    }
+  get active() {
+    return this.shadowRoot.querySelector(".active").innerText;
   }
 
   /**
    * Toggle the active of date
    */
   set active(active) {
-    if (active == 'true') {
+    if (active == "true") {
       this.shadowRoot.querySelector(".date").style.backgroundColor =
         "rgba(60, 77, 87, 0.925)";
-      this.shadowRoot.querySelector(".active").innerText = "true";
     } else {
       this.shadowRoot.querySelector(".date").style.backgroundColor =
         "rgba(167, 200, 220, 0.925)";
-      this.shadowRoot.querySelector(".active").innerHTML = "false";
     }
     this.shadowRoot.querySelector(".active").innerText = active;
   }
+
   get obj() {
     let dateObj = {
       date: this.shadowRoot.querySelector(".date").innerText,
-      active: this.shadowRoot.querySelector('.active').innerText,
+      active: this.shadowRoot.querySelector(".active").innerText,
     };
     return dateObj;
   }

--- a/sources/components/dateEntry.js
+++ b/sources/components/dateEntry.js
@@ -71,7 +71,7 @@ class DateEntry extends HTMLElement {
   set active(active) {
     if (active == "true") {
       this.shadowRoot.querySelector(".date").style.backgroundColor =
-        "rgba(60, 77, 87, 0.925)";
+        "rgba(107, 140, 160, 0.925)";
     } else {
       this.shadowRoot.querySelector(".date").style.backgroundColor =
         "rgba(167, 200, 220, 0.925)";
@@ -79,12 +79,25 @@ class DateEntry extends HTMLElement {
     this.shadowRoot.querySelector(".active").innerText = active;
   }
 
+  /**
+   * Return the date object
+   */
   get obj() {
     let dateObj = {
       date: this.shadowRoot.querySelector(".date").innerText,
       active: this.shadowRoot.querySelector(".active").innerText,
     };
     return dateObj;
+  }
+
+  set disabled(disabled){
+    if (disabled ==true) {
+      this.shadowRoot.querySelector(".date").style.backgroundColor =
+        "rgba(160, 177, 187, 0.925)";
+    } else {
+      this.shadowRoot.querySelector(".date").style.backgroundColor =
+        "rgba(167, 200, 220, 0.925)";
+    }
   }
 }
 

--- a/sources/scripts/script.js
+++ b/sources/scripts/script.js
@@ -103,6 +103,8 @@ document.addEventListener("click", (e) => {
   if (e.composedPath()[0].className == "date") {
     let dateElement = e.composedPath()[0].getRootNode().host;
     storage.updateActiveDates(dateElement);
+    //Add diabled interface for date selector if no date is selected
+    checkDateSelector();
   }
   // Check bullet event
   if (e.composedPath()[0].id == "bullet-check") {
@@ -110,6 +112,26 @@ document.addEventListener("click", (e) => {
     storage.editBullet(bulletElement.bullet, bulletElement.bullet);
   }
 });
+
+function checkDateSelector() {
+  let dates = document.querySelectorAll("date-entry");
+  let historyBox = document.querySelector(".journal-box-history");
+  if (storage.activeDates.size == 0) {
+    historyBox.style.backgroundColor = "rgb(202, 207, 210)";
+    dates.forEach((date) => {
+      date.disabled = true;
+    });
+  } else {
+    historyBox.style.backgroundColor = "rgb(210, 221, 232)";
+    dates.forEach((date) => {
+      if (storage.activeDates.has(date.date)) {
+        date.active = "true";
+      } else {
+        date.active = "false";
+      }
+    });
+  }
+}
 
 // Helper function for bullet showDetail button
 function showDetail(detailButton) {

--- a/sources/scripts/storage.js
+++ b/sources/scripts/storage.js
@@ -5,7 +5,7 @@ var dateArr;
 
 // Only store actives in current session
 var activeCategories = new Map();
-var activeDates = new Map();
+export var activeDates = new Map();
 
 if (myStorage.getItem("bulletArr")) {
   bulletArr = JSON.parse(myStorage.getItem("bulletArr"));

--- a/sources/styles.css
+++ b/sources/styles.css
@@ -1,7 +1,7 @@
 /* This is a style css to the index.html in the root */
 body {
   overflow-y: auto;
-  overflow-x:hidden;
+  overflow-x: hidden;
   background-color: rgb(173, 210, 244);
   height: 100%;
   width: 100%;
@@ -34,7 +34,6 @@ body.main-view main .container {
   position: relative;
   z-index: initial;
   min-width: 1060px;
-
 }
 
 /* Stlying for the first cell(top left cell, add button) */

--- a/sources/styles.css
+++ b/sources/styles.css
@@ -1,8 +1,10 @@
 /* This is a style css to the index.html in the root */
 body {
   overflow-y: auto;
-  overflow-x: auto;
+  overflow-x:hidden;
   background-color: rgb(173, 210, 244);
+  height: 100%;
+  width: 100%;
 }
 
 /* Stlying for the first cell(top left cell, add button) */
@@ -10,7 +12,7 @@ body {
   margin-top: -0.5rem;
   margin-left: -0.5rem;
   margin-right: -0.5rem;
-  width: 98%;
+  width: 100%;
   background-color: rgb(9, 65, 114);
   text-align: center;
   font-size: 2rem;
@@ -20,8 +22,8 @@ body {
 
 /* Styling for the main container that will hold all our cells */
 body.main-view main .container {
-  height: 90vh;
-  width: 97.6vw;
+  height: 100%;
+  width: 99%;
   display: grid;
   grid-template-areas:
     "history      main cateMa"
@@ -31,6 +33,8 @@ body.main-view main .container {
   grid-template-columns: 1fr 2fr 1fr;
   position: relative;
   z-index: initial;
+  min-width: 1060px;
+
 }
 
 /* Stlying for the first cell(top left cell, add button) */
@@ -89,7 +93,7 @@ body.main-view main .section-header-main {
 
 /* Styling for the journal entries shown in the history box */
 body.main-view main .journal-box-history {
-  background-color: rgb(210, 221, 232);
+  background-color: rgb(247, 249, 250);
   margin-top: 0.3em;
   padding: 0.5em;
   height: 45rem;


### PR DESCRIPTION
Add a new ui feature:
When there is no date get selected, the day selected box will gray out, which looks like disabled.
In this way, it is more intuitive for the user to realize the day selector is a soft filter (when no date is selected, all day is selected)